### PR TITLE
CA-161 add publication date/time to videos and articles

### DIFF
--- a/components/Article.js
+++ b/components/Article.js
@@ -6,12 +6,14 @@ import ContentCard from "./ContentCard";
 import { accentColor } from "../config/defaultStyles";
 import AuthContext from "../auth/Context";
 import { trackClick } from "./TrackClick";
+import defaultStyles from "../config/defaultStyles";
 
 const Article = (props) => {
   const authContext = useContext(AuthContext);
   return (
     <ContentCard>
       <Title>{props.article.item_object.title}</Title>
+      <Text style={defaultStyles.publishDate}>{props.article.publication_date_time}</Text>
       <Paragraph numberOfLines={2}>
         {props.article.item_object.description}
       </Paragraph>

--- a/components/Video.js
+++ b/components/Video.js
@@ -1,11 +1,12 @@
 import React, { useContext } from "react";
 import { StyleSheet, View, TouchableOpacity } from "react-native";
 import { WebView } from "react-native-webview";
-import { Title, Paragraph } from "react-native-paper";
+import { Title, Paragraph, Text } from "react-native-paper";
 import PropTypes from "prop-types";
 import ContentCard from "./ContentCard";
 import AuthContext from "../auth/Context";
 import { trackClick } from "./TrackClick";
+import defaultStyles from "../config/defaultStyles";
 
 const Video = (props) => {
   const authContext = useContext(AuthContext);
@@ -16,6 +17,7 @@ const Video = (props) => {
     <ContentCard>
       <View>
         <Title>{props.video.item_object.title}</Title>
+        <Text style={defaultStyles.publishDate}>{props.video.publication_date_time}</Text>
         <TouchableOpacity
           style={styles.videoContainer}
           onPress={click}

--- a/config/defaultStyles.js
+++ b/config/defaultStyles.js
@@ -83,6 +83,10 @@ export default {
         height: 150,
         flex: 1,
     },
+  publishDate: {
+    size: 9,
+    marginVertical: 10,
+  },
 
     button: {
         borderRadius: 6,

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -105,6 +105,9 @@ export default function HomeScreen() {
       postData(payLoad);
     };
 
+    // add publication_date_time to content object, to be passed to components
+    props.content.content['publication_date_time'] = props.content.publication_date_time;
+
     if (props.content.content.item_type == "Question") {
       return (
         <Question


### PR DESCRIPTION
This is not actually part of CA-161 (timezones) but I wanted to get the publication date on the screen, per wireframes, before I start messing with the timezone/formatting aspect of it - to keep the next PR clean.